### PR TITLE
add mysql-dev so that we can use the mysql2 gem [PD-7]

### DIFF
--- a/ruby-2.3.3/Dockerfile
+++ b/ruby-2.3.3/Dockerfile
@@ -6,7 +6,7 @@ ENV BUNDLER_VERSION 1.13.6
 ENV GEM_HOME /usr/local/bundle
 ENV BUNDLE_APP_CONFIG $GEM_HOME
 ENV PASSENGER passenger-5.0.30
-ENV RUBY_PACKAGES ca-certificates curl-dev file imagemagick libxml2-dev libxslt-dev linux-headers nginx nodejs postgresql-client procps readline-dev ruby-rake tzdata
+ENV RUBY_PACKAGES ca-certificates curl-dev file imagemagick libxml2-dev libxslt-dev linux-headers mysql-dev nginx nodejs postgresql-client procps readline-dev ruby-rake tzdata
 ENV RUBY_VERSION 2.3.3
 ENV RUBYGEMS_VERSION 2.6.8
 


### PR DESCRIPTION
[JIRA PD-7](https://parkwhiz.atlassian.net/browse/PD-7)

The `mysql2` gem will fail to build native extensions without this dependency.

See also:
https://github.com/ParkWhiz/pw_admin/pull/327
https://github.com/ParkWhiz/pw_core_data/pull/402
https://github.com/ParkWhiz/workers/pull/56