### PR TITLE
add nano to the circleCI docker container

### DIFF
--- a/ruby-2.3.3-circleci/Dockerfile
+++ b/ruby-2.3.3-circleci/Dockerfile
@@ -15,8 +15,9 @@ RUN \
     postgresql-9.4-postgis-2.1 \
     postgresql-client-9.4 \
     software-properties-common \
+    nano \
     sudo && \
-  wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 && \
+  wget -O phantomjs-2.1.1-linux-x86_64.tar.bz2 "https://bbuseruploads.s3.amazonaws.com/fd96ed93-2b32-46a7-9d2b-ecbc0988516a/downloads/396e7977-71fd-4592-8723-495ca4cfa7cc/phantomjs-2.1.1-linux-x86_64.tar.bz2?Signature=%2Bgz4y5Xpi5%2F2l%2BKWTKH5YCLGILU%3D&Expires=1508283133&AWSAccessKeyId=AKIAIQWXW6WLXMB5QZAQ&versionId=null&response-content-disposition=attachment%3B%20filename%3D%22phantomjs-2.1.1-linux-x86_64.tar.bz2%22" && \
   tar -xvf phantomjs-2.1.1-linux-x86_64.tar.bz2 && \
   cd phantomjs-2.1.1-linux-x86_64/bin && \
   ln -s `pwd`/phantomjs /usr/local/bin/phantomjs && \


### PR DESCRIPTION
to troubleshoot builds via ssh

wget was running into a redirect loop when fetching the phantomjs library
It only happened in the container but this resolves it.