### PR TITLE
add new targets for Ruby 2.3.7 and Passenger 5.3.2 [ct-66]

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "Which image would you like to build? (e.g. 2.3.3, 2.3.3-circleci)?"
+echo "Which image would you like to build? (e.g. 2.3.7, 2.3.7-circleci)?"
 read ruby_version
 
 if [ ! -d "ruby-$ruby_version" ]; then

--- a/ruby-2.3.7-circleci/Dockerfile
+++ b/ruby-2.3.7-circleci/Dockerfile
@@ -1,0 +1,37 @@
+FROM ruby:2.3.7
+
+RUN \
+  apt-get update && \
+  apt-get upgrade -y && \
+  apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    cmake \
+    curl \
+    gnupg2 \
+    liblwgeom-2.1.4 \
+    nodejs \
+    postgresql-9.4 \
+    postgresql-9.4-plv8 \
+    postgresql-9.4-postgis-2.1 \
+    postgresql-client-9.4 \
+    software-properties-common \
+    nano \
+    sudo && \
+  wget -O phantomjs-2.1.1-linux-x86_64.tar.bz2 "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2" && \
+  tar -xvf phantomjs-2.1.1-linux-x86_64.tar.bz2 && \
+  cd phantomjs-2.1.1-linux-x86_64/bin && \
+  ln -s `pwd`/phantomjs /usr/local/bin/phantomjs && \
+  curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
+  add-apt-repository \
+    "deb [arch=amd64] https://download.docker.com/linux/debian \
+    $(lsb_release -cs) \
+    stable" && \
+  apt-get update && \
+  apt-get install -y docker-ce && \
+  service postgresql start && \
+  sudo -u postgres createuser -d -s root && \
+  service postgresql stop && \
+  rm -rf /var/lib/apt/lists/*
+
+CMD /bin/bash

--- a/ruby-2.3.7/Dockerfile
+++ b/ruby-2.3.7/Dockerfile
@@ -1,0 +1,47 @@
+FROM alpine:3.4
+MAINTAINER ParkWhiz <dev@parkwhiz.com>
+
+ENV BUILD_PACKAGES autoconf bison build-base curl git libc-dev libstdc++ openssl-dev pcre pcre-dev postgresql-dev procps ruby-dev wget
+ENV BUNDLER_VERSION 1.16.1
+ENV GEM_HOME /usr/local/bundle
+ENV BUNDLE_APP_CONFIG $GEM_HOME
+ENV PASSENGER passenger-5.2.3
+ENV RUBY_PACKAGES ca-certificates curl-dev file imagemagick libxml2-dev libxslt-dev linux-headers mysql-dev nginx nodejs postgresql-client procps readline-dev ruby-rake tzdata
+ENV RUBY_VERSION 2.3.7
+ENV RUBYGEMS_VERSION 2.7.2
+
+ENV PATH "$GEM_HOME/bin:/passenger/bin:$PATH"
+
+RUN \
+  apk update && \
+  apk upgrade && \
+  apk add bash && \
+  apk add --virtual build-dependencies $BUILD_PACKAGES && \
+  apk add --virtual ruby-packages $RUBY_PACKAGES && \
+  mkdir -p /usr/src/ruby && \
+  curl -fSL -o ruby.tar.gz "https://cache.ruby-lang.org/pub/ruby/$RUBY_MAJOR/ruby-$RUBY_VERSION.tar.gz" && \
+  tar -xzf ruby.tar.gz -C /usr/src/ruby && \
+  rm ruby.tar.gz && \
+  cd "/usr/src/ruby/ruby-$RUBY_VERSION" && \
+  autoconf && \
+  ./configure --disable-install-doc --with-readline-dir=/usr/ && \
+  make -j"$(nproc)" && \
+  make install && \
+  gem update -N --system $RUBY_GEMS_VERSION && \
+  rm -rf /usr/src/ruby && \
+  cd ~/ && \
+  apk add --update-cache --virtual passenger-dependencies --repository https://nl.alpinelinux.org/alpine/edge/main libexecinfo libexecinfo-dev && \
+  curl -fSL "https://s3.amazonaws.com/phusion-passenger/releases/$PASSENGER.tar.gz" | tar xvz && \
+  mv "$PASSENGER/" /passenger && \
+  cd /passenger && \
+  export EXTRA_PRE_CFLAGS='-O' EXTRA_PRE_CXXFLAGS='-O' EXTRA_LDFLAGS='-lexecinfo' && \
+  passenger-config install-standalone-runtime --auto --connect-timeout=60 && \
+  passenger-config build-native-support && \
+  passenger-config validate-install --auto && \
+  gem install bundler --no-rdoc --no-ri --no-doc --version "$BUNDLER_VERSION" && \
+  bundle config --global path "$GEM_HOME" && \
+  bundle config --global bin "$GEM_HOME/bin" && \
+  gem install nokogiri -v 1.6.7 --no-rdoc --no-ri --no-doc -- --use-system-libraries && \
+  gem install rb-readline --no-rdoc --no-ri --no-doc && \
+  gem install json -v 1.8.3 --no-rdoc --no-ri --no-doc && \
+  rm -rf /var/cache/apk/*

--- a/ruby-2.3.7/Dockerfile
+++ b/ruby-2.3.7/Dockerfile
@@ -2,13 +2,13 @@ FROM alpine:3.4
 MAINTAINER ParkWhiz <dev@parkwhiz.com>
 
 ENV BUILD_PACKAGES autoconf bison build-base curl git libc-dev libstdc++ openssl-dev pcre pcre-dev postgresql-dev procps ruby-dev wget
-ENV BUNDLER_VERSION 1.16.1
+ENV BUNDLER_VERSION 1.16.2
 ENV GEM_HOME /usr/local/bundle
 ENV BUNDLE_APP_CONFIG $GEM_HOME
-ENV PASSENGER passenger-5.3.0
+ENV PASSENGER passenger-5.3.2
 ENV RUBY_PACKAGES ca-certificates curl-dev file imagemagick libxml2-dev libxslt-dev linux-headers mysql-dev nginx nodejs postgresql-client procps readline-dev ruby-rake tzdata
 ENV RUBY_VERSION 2.3.7
-ENV RUBYGEMS_VERSION 2.7.2
+ENV RUBYGEMS_VERSION 2.7.7
 
 ENV PATH "$GEM_HOME/bin:/passenger/bin:$PATH"
 

--- a/ruby-2.3.7/Dockerfile
+++ b/ruby-2.3.7/Dockerfile
@@ -5,7 +5,7 @@ ENV BUILD_PACKAGES autoconf bison build-base curl git libc-dev libstdc++ openssl
 ENV BUNDLER_VERSION 1.16.1
 ENV GEM_HOME /usr/local/bundle
 ENV BUNDLE_APP_CONFIG $GEM_HOME
-ENV PASSENGER passenger-5.2.3
+ENV PASSENGER passenger-5.3.0
 ENV RUBY_PACKAGES ca-certificates curl-dev file imagemagick libxml2-dev libxslt-dev linux-headers mysql-dev nginx nodejs postgresql-client procps readline-dev ruby-rake tzdata
 ENV RUBY_VERSION 2.3.7
 ENV RUBYGEMS_VERSION 2.7.2


### PR DESCRIPTION
Upgrade
* Ruby to 2.3.7
* Ruby Gems 2.7.7
* Bundler 1.16.2
* Passenger 5.3.2
* Add `cmake` to the circleci image (used by `pronto` for Ruby linting)
