### PR TITLE
Fix debian deprecation in the greenlight docker container

### DIFF
--- a/greenlight-cinc-22/Dockerfile
+++ b/greenlight-cinc-22/Dockerfile
@@ -1,4 +1,4 @@
-FROM parkwhiz/rails-base:3.0.2_20210812134927
+FROM ruby:latest
 MAINTAINER ParkWhiz <dev@parkwhiz.com>
 
 WORKDIR /


### PR DESCRIPTION
DOPS-1345

https://github.com/ParkWhiz/greenlight/pull/965
https://github.com/ParkWhiz/rails-base/pull/25
